### PR TITLE
ENH: add state_changed callback on channels

### DIFF
--- a/caproto/_hub.py
+++ b/caproto/_hub.py
@@ -233,8 +233,8 @@ class VirtualCircuit:
             # Update the state machine of the pertinent Channel.
             # If this is not a valid command, the state machine will raise
             # here.
-            chan._state.process_command(self.our_role, type(command))
-            chan._state.process_command(self.their_role, type(command))
+            chan._process_command(self.our_role, type(command))
+            chan._process_command(self.their_role, type(command))
 
             # If we got this far, the state machine has validated this Command.
             # Update other Channel and Circuit state.
@@ -585,6 +585,17 @@ class _BaseChannel:
         if data_count is None:
             data_count = self.native_data_count
         return data_type, data_count
+
+    def state_changed(self, role, old_state, new_state):
+        '''State changed callback for subclass usage'''
+        pass
+
+    def _process_command(self, role, command):
+        initial_state = self._state[role]
+        self._state.process_command(role, command)
+        new_state = self._state[role]
+        if initial_state is not new_state:
+            self.state_changed(role, initial_state, new_state)
 
 
 class ClientChannel(_BaseChannel):

--- a/caproto/_state.py
+++ b/caproto/_state.py
@@ -25,6 +25,7 @@ COMMAND_TRIGGERED_CIRCUIT_TRANSITIONS = {
             EchoRequest: SEND_VERSION_REQUEST,
             EchoResponse: SEND_VERSION_REQUEST,
             VersionRequest: AWAIT_VERSION_RESPONSE,
+            VersionResponse: CONNECTED,
             ErrorResponse: ERROR,
         },
         AWAIT_VERSION_RESPONSE: {
@@ -42,6 +43,8 @@ COMMAND_TRIGGERED_CIRCUIT_TRANSITIONS = {
             HostNameRequest: CONNECTED,
             ClientNameRequest: CONNECTED,
             AccessRightsResponse: CONNECTED,
+            VersionRequest: AWAIT_VERSION_RESPONSE,
+            VersionResponse: CONNECTED,
             ErrorResponse: ERROR,
             # VirtualCircuits can only be closed by timeout.
         },
@@ -49,6 +52,9 @@ COMMAND_TRIGGERED_CIRCUIT_TRANSITIONS = {
     },
     SERVER: {
         IDLE: {
+            # C channel access server (rsrv) sends VersionResponse upon
+            # connection
+            VersionResponse: CONNECTED,
             VersionRequest: SEND_VERSION_RESPONSE,
             EchoRequest: IDLE,
             EchoResponse: IDLE,
@@ -65,6 +71,7 @@ COMMAND_TRIGGERED_CIRCUIT_TRANSITIONS = {
         },
         CONNECTED: {
             # Host and Client requests may come before or after we connect.
+            VersionRequest: SEND_VERSION_RESPONSE,
             HostNameRequest: CONNECTED,
             ClientNameRequest: CONNECTED,
             AccessRightsResponse: CONNECTED,

--- a/caproto/_state.py
+++ b/caproto/_state.py
@@ -170,6 +170,9 @@ class _BaseState:
     def __repr__(self):
         return "<{!s} states={!r}>".format(type(self).__name__, self.states)
 
+    def __getitem__(self, role):
+        return self.states[role]
+
     def _fire_command_triggered_transitions(self, role, command_type):
         state = self.states[role]
         try:


### PR DESCRIPTION
This may not be how it was intended to be used - here for discussion.
Should instead the virtual circuit be monitoring what happens to the
channels instead of the channels themselves?