### PR TITLE
FIX: Parse CHAR waveform as bytes not numpy array of chars.

### DIFF
--- a/caproto/_dbr.py
+++ b/caproto/_dbr.py
@@ -965,7 +965,6 @@ if USE_NUMPY:
         ChType.LONG: numpy.int32,
         ChType.DOUBLE: numpy.float64,
         ChType.STRING: numpy.dtype('>S40'),
-        ChType.CHAR: numpy.dtype('>S1')
     }
 
 _array_type_code_map = {

--- a/caproto/_dbr.py
+++ b/caproto/_dbr.py
@@ -1045,6 +1045,8 @@ def native_to_builtin(value, native_type, data_count):
     #   character) strings.
     # - Enums are just integers that happen to have special significance.
     # - Everything else is, straightforwardly, an array of numbers.
+    if native_type == ChType.CHAR:
+        return value
     if USE_NUMPY:
         # Return an ndarray
         dt = numpy.dtype(_numpy_map[native_type])

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -479,7 +479,7 @@ class PV:
 
         ret = info['value']
         if as_string and self.typefull in ca.char_types:
-            ret = ret.strip(b'\x00').decode('utf-8')
+            ret = ret.partition(b'\x00')[0].decode('utf-8')
             info['char_value'] = ret
         elif self.typefull in ca.string_types:
             ret = [v.decode('utf-8').strip() for v in ret]

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -479,7 +479,7 @@ class PV:
 
         ret = info['value']
         if as_string and self.typefull in ca.char_types:
-            ret = (b''.join(ret)).decode('utf-8').strip()
+            ret = ret.strip(b'\x00').decode('utf-8')
             info['char_value'] = ret
         elif self.typefull in ca.string_types:
             ret = [v.decode('utf-8').strip() for v in ret]


### PR DESCRIPTION
I think this is what we agreed on yesterday (and it's what is explained in the comments for this function) but somehow the implementation got lost. All the same tests pass; this is just a quality-of-life measure.