### PR TITLE
Revert "FIX: Parse CHAR waveform as bytes not numpy array of chars."

### DIFF
--- a/caproto/_dbr.py
+++ b/caproto/_dbr.py
@@ -965,6 +965,7 @@ if USE_NUMPY:
         ChType.LONG: numpy.int32,
         ChType.DOUBLE: numpy.float64,
         ChType.STRING: numpy.dtype('>S40'),
+        ChType.CHAR: numpy.dtype('>S1')
     }
 
 _array_type_code_map = {
@@ -1044,8 +1045,6 @@ def native_to_builtin(value, native_type, data_count):
     #   character) strings.
     # - Enums are just integers that happen to have special significance.
     # - Everything else is, straightforwardly, an array of numbers.
-    if native_type == ChType.CHAR:
-        return value
     if USE_NUMPY:
         # Return an ndarray
         dt = numpy.dtype(_numpy_map[native_type])

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -484,7 +484,7 @@ class PV:
 
         ret = info['value']
         if as_string and self.typefull in ca.char_types:
-            ret = ret.partition(b'\x00')[0].decode('utf-8')
+            ret = (b''.join(ret)).decode('utf-8').strip()
             info['char_value'] = ret
         elif self.typefull in ca.string_types:
             ret = [v.decode('utf-8').strip() for v in ret]


### PR DESCRIPTION
Reverts danielballan/caproto#51

Consensus changed. Although bytes are a simpler way to represent a waveform of characters, having *everything* return as a numpy array is nicer, and it's very easy to convert to bytes if desired.