### PR TITLE
API: Rename Channel.clear() -> Channel.disconnect()

### DIFF
--- a/caproto/_hub.py
+++ b/caproto/_hub.py
@@ -707,7 +707,7 @@ class ClientChannel(_BaseChannel):
                                     self.protocol_version)
         return command
 
-    def clear(self):
+    def disconnect(self):
         """
         Generate a valid :class:`ClearChannelRequest`.
 
@@ -893,7 +893,7 @@ class ServerChannel(_BaseChannel):
         command = CreateChFailResponse(self.cid)
         return command
 
-    def clear(self):
+    def disconnect(self):
         """
         Generate a valid :class:`ClearChannelResponse`.
 

--- a/caproto/curio/client.py
+++ b/caproto/curio/client.py
@@ -139,9 +139,9 @@ class Channel:
             event = await self.circuit.get_event()
             await event.wait()
 
-    async def clear(self):
+    async def disconnect(self):
         "Disconnect this Channel."
-        await self.circuit.send(self.channel.clear())
+        await self.circuit.send(self.channel.disconnect())
         while self.channel.states[ca.CLIENT] is ca.MUST_CLOSE:
             event = await self.circuit.get_event()
             await event.wait()
@@ -374,8 +374,8 @@ async def main():
     await chan1.write((6,))
     reading = await chan1.read()
     print('reading:', reading)
-    await chan2.clear()
-    await chan1.clear()
+    await chan2.disconnect()
+    await chan1.disconnect()
     assert called
 
 

--- a/caproto/curio/server.py
+++ b/caproto/curio/server.py
@@ -146,7 +146,7 @@ class VirtualCircuit:
             yield chan.unsubscribe(command.subscriptionid)
         elif isinstance(command, ca.ClearChannelRequest):
             chan, db_entry = get_db_entry()
-            yield chan.clear()
+            yield chan.disconnect()
 
 
 class Context:

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -301,7 +301,7 @@ class VirtualCircuit:
 
     def disconnect(self):
         for cid, ch in list(self.channels.items()):
-            ch.clear()
+            ch.disconnect()
             self.channels.pop(cid)
 
         with self.has_new_command:
@@ -361,12 +361,12 @@ class Channel:
         """
         raise NotImplemented()
 
-    def clear(self):
+    def disconnect(self):
         "Disconnect this Channel."
         with self.circuit.has_new_command:
             if self.connected:
                 try:
-                    self.circuit.send(self.channel.clear())
+                    self.circuit.send(self.channel.disconnect())
                 except OSError:
                     # the socket is dead-dead, return
                     return
@@ -1089,7 +1089,7 @@ class PV:
     def disconnect(self):
         "disconnect PV"
         if self.connected:
-            self.chid.clear()
+            self.chid.disconnect()
 
     def __del__(self):
         self.disconnect()

--- a/doc/source/basics.rst
+++ b/doc/source/basics.rst
@@ -422,7 +422,7 @@ See how much more succinct our example becomes:
     recv()
 
     ### Clear
-    send(chan.clear())
+    send(chan.disconnect())
     recv()
 
 Here is the equivalent, a condensed copy of our work from previous sections:

--- a/doc/source/curio-client.rst
+++ b/doc/source/curio-client.rst
@@ -68,8 +68,8 @@ caproto as a CLI.
         await chan1.write((6,))
         reading = await chan1.read()
         print('reading:', reading)
-        await chan2.clear()
-        await chan1.clear()
+        await chan2.disconnect()
+        await chan1.disconnect()
 
         # Verify that our subscription collected some results.
         assert called

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -110,8 +110,8 @@ def test_thread_client():
     reading = chan1.read()
     assert reading.data == 6
     print('reading:', reading)
-    chan2.clear()
-    chan1.clear()
+    chan2.disconnect()
+    chan1.disconnect()
     assert called
 
 
@@ -205,7 +205,7 @@ def test_curio_server():
         await chan1.write((6,))
         reading = await chan1.read()
         print('reading:', reading)
-        await chan1.clear()
+        await chan1.disconnect()
         assert called
         await chan1.circuit.socket.close()
 

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -279,7 +279,7 @@ def test_clear(circuit_pair):
     assert cli_channel.states[ca.SERVER] is ca.CONNECTED
 
     # Send request to clear.
-    buffers_to_send = cli_circuit.send(cli_channel.clear())
+    buffers_to_send = cli_circuit.send(cli_channel.disconnect())
     assert cli_channel.states[ca.CLIENT] is ca.MUST_CLOSE
     assert cli_channel.states[ca.SERVER] is ca.MUST_CLOSE
 
@@ -290,7 +290,7 @@ def test_clear(circuit_pair):
     assert srv_channel.states[ca.SERVER] is ca.MUST_CLOSE
 
     # Send confirmation.
-    buffers_to_send = srv_circuit.send(srv_channel.clear())
+    buffers_to_send = srv_circuit.send(srv_channel.disconnect())
     assert srv_channel.states[ca.CLIENT] is ca.CLOSED
     assert srv_channel.states[ca.SERVER] is ca.CLOSED
 


### PR DESCRIPTION
Astoundingly, this rename is made at the request of @tacaswell.

He argues that `ServerChannel.disconnect()` and `ClientChannel.clear()` is a weird asymmetry in EPICS naming that we should hide for consistency at the client/server layer or probably at the hub layer too. I can see it either way, and I'm perfectly happy to change it at this stage.