### PR TITLE
ENH/TST: Support put completion in threading client.

### DIFF
--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -295,10 +295,10 @@ class VirtualCircuit:
 
                 if isinstance(command, ca.ReadNotifyResponse):
                     chan = self.ioids.pop(command.ioid)
-                    chan.process_readnotify(command)
+                    chan.process_read_notify(command)
                 elif isinstance(command, ca.WriteNotifyResponse):
                     chan = self.ioids.pop(command.ioid)
-                    chan.process_writenotify(command)
+                    chan.process_write_notify(command)
                 elif isinstance(command, ca.EventAddResponse):
                     chan = self.subscriptionids[command.subscriptionid]
                     chan.process_subscription(command)
@@ -332,7 +332,8 @@ class VirtualCircuit:
 class Channel:
     """Wraps a VirtualCircuit and a caproto.ClientChannel."""
     __slots__ = ('circuit', 'channel', 'last_reading', 'monitoring_tasks',
-                 '_callback')
+                 '_callback', '_read_notify_callback',
+                 '_write_notify_callback')
 
     def __init__(self, circuit, channel):
         self.circuit = circuit  # a VirtualCircuit
@@ -367,7 +368,7 @@ class Channel:
             except Exception as ex:
                 print(ex)
 
-    def process_readnotify(self, read_notify_command):
+    def process_read_notify(self, read_notify_command):
         self.last_reading = read_notify_command
 
         if self._read_notify_callback is None:
@@ -378,7 +379,7 @@ class Channel:
             except Exception as ex:
                 print(ex)
 
-    def process_writenotify(self, write_notify_command):
+    def process_write_notify(self, write_notify_command):
         if self._write_notify_callback is None:
             return
         else:

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -763,7 +763,9 @@ class PV:
         def run_callback(cmd):
             callback(*callback_data)
         cb = run_callback if callback is not None else None
-        return self.chid.write(value, wait=wait, cb=cb)
+        ret = self.value
+        self.chid.write(value, wait=wait, cb=cb)
+        return ret if wait else None
 
     @ensure_connection
     def get_ctrlvars(self, timeout=5, warn=True):

--- a/caproto/threading/client.py
+++ b/caproto/threading/client.py
@@ -617,7 +617,6 @@ class PV:
         self._args['access'] = access_strs[self.chid.channel.access_rights]
 
         self.chid.register_user_callback(self.__on_changes)
-        self.chid._read_notify_callback = self.__on_changes
 
         if self.auto_monitor is None:
             mcount = count if count is not None else self._args['count']

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -140,8 +140,8 @@ def test_thread_pv():
     print('time read', time_pv.get())
     print('ctrl read', ctrl_pv.get())
 
-    time_pv.put(3)
-    time_pv.put(6)
+    time_pv.put(3, wait=True)
+    time_pv.put(6, wait=True)
 
     time.sleep(0.1)
     assert time_pv.get() == 6


### PR DESCRIPTION
This fixes an accidental API mismatch with pyepics: get() and put() should return ``command.data``, not ``command``.